### PR TITLE
Allow for nil end date when start date is specified

### DIFF
--- a/gocal.go
+++ b/gocal.go
@@ -63,8 +63,11 @@ func (gc *Gocal) Parse() error {
 			if gc.buffer.IsRecurring {
 				rInstances = append(rInstances, gc.ExpandRecurringEvent(gc.buffer)...)
 			} else {
-				if gc.buffer.End == nil || gc.buffer.Start == nil {
+				if gc.buffer.Start == nil {
 					continue
+				}
+				if gc.buffer.End == nil {
+					gc.buffer.End = gc.buffer.Start
 				}
 				if gc.buffer.End.Before(*gc.Start) || gc.buffer.Start.After(*gc.End) {
 					continue


### PR DESCRIPTION
When specifying the same start date and end date in Google Calendar, the ical feed does not output an end date and gocal skips these entries.  This copies to value provided in the start date to the end date.  