### PR TITLE
Expand recurring event enh

### DIFF
--- a/rrule.go
+++ b/rrule.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/apognu/gocal/parser"
-	"subsplash.io/go/kit/ptr"
 )
 
 const YmdHis = "2006-01-02 15:04:05"
@@ -94,8 +93,10 @@ func (gc *Gocal) ExpandRecurringEvent(buf *Event) []Event {
 
 						if strings.Contains(byDay, day) {
 							if currentCount != 0 {
-								weekDaysStart = ptr.Time(weekDaysStart.AddDate(0, 0, (dayRecurrence-1)*7))
-								weekDaysEnd = ptr.Time(weekDaysEnd.AddDate(0, 0, (dayRecurrence-1)*7))
+								recurrWeekDaysStart := weekDaysStart.AddDate(0, 0, (dayRecurrence-1)*7)
+								recurrWeekDaysEnd := weekDaysEnd.AddDate(0, 0, (dayRecurrence-1)*7)
+								weekDaysStart = &recurrWeekDaysStart
+								weekDaysEnd = &recurrWeekDaysEnd
 							}
 							currentCount++
 							count--


### PR DESCRIPTION
1) Added support for day recurrence (i.e. BYDAY=**3**TU) :: [lines 36-44, 95-100]
2) Break out of 'for' loop once date is found :: [line 115]
3) Once first date in recurring series is found and newStart and newEnd are reset, roll back to the first of the month of newStart and set newEnd accordingly :: [lines 151-158]
      NOTE:  This change was added because test cases like this were failing:
            I correctly received an event on 11/04/2019, but since 1 month was added to this start date, the next month started looking for "first monday" on 12/04/2019 and returned 12/09/2019 when it should have returned 12/02/2019.

**TEST CASE EXAMPLE:**
BEGIN:VEVENT
DTSTART;TZID=America/Los_Angeles:20191104T090000
DTEND;TZID=America/Los_Angeles:20191104T100000
RRULE:FREQ=MONTHLY;BYDAY=1MO
DTSTAMP:20191023T175925Z
UID:6uvrlpou5dsso6hnng6p65es41@google.com
CREATED:20191021T154144Z
DESCRIPTION:
LAST-MODIFIED:20191021T220941Z
LOCATION:
SEQUENCE:1
STATUS:CONFIRMED
SUMMARY:Test Monthly First Monday
TRANSP:OPAQUE
END:VEVENT


Attached is a test file I used to verify my changes in multiple scenarios.
[multiRecurrExamples.ics.txt](https://github.com/apognu/gocal/files/3770330/multiRecurrExamples.ics.txt)

