### PR TITLE
Parse COMMENT VEVENT property and ATTENDEE custom attributes

### DIFF
--- a/gocal.go
+++ b/gocal.go
@@ -318,8 +318,8 @@ func (gc *Gocal) parseEvent(l *Line) error {
 		gc.buffer.Categories = strings.Split(l.Value, ",")
 	case "URL":
 		gc.buffer.URL = l.Value
-    case "COMMENT":
-        gc.buffer.Comment = l.Value
+	case "COMMENT":
+		gc.buffer.Comment = l.Value
 	default:
 		key := strings.ToUpper(l.Key)
 		if strings.HasPrefix(key, "X-") {

--- a/gocal.go
+++ b/gocal.go
@@ -274,12 +274,28 @@ func (gc *Gocal) parseEvent(l *Line) error {
 			Value:       l.Value,
 		}
 	case "ATTENDEE":
-		gc.buffer.Attendees = append(gc.buffer.Attendees, Attendee{
-			Cn:          l.Params["CN"],
-			DirectoryDn: l.Params["DIR"],
-			Status:      l.Params["PARTSTAT"],
-			Value:       l.Value,
-		})
+		attendee := Attendee{
+			Value: l.Value,
+		}
+		for key, val := range l.Params {
+			key := strings.ToUpper(key)
+			switch key {
+			case "CN":
+				attendee.Cn = val
+			case "DIR":
+				attendee.DirectoryDn = val
+			case "PARTSTAT":
+				attendee.Status = val
+			default:
+				if strings.HasPrefix(key, "X-") {
+					if attendee.CustomAttributes == nil {
+						attendee.CustomAttributes = make(map[string]string)
+					}
+					attendee.CustomAttributes[key] = val
+				}
+			}
+		}
+		gc.buffer.Attendees = append(gc.buffer.Attendees, attendee)
 	case "ATTACH":
 		gc.buffer.Attachments = append(gc.buffer.Attachments, Attachment{
 			Type:     l.Params["VALUE"],
@@ -302,6 +318,8 @@ func (gc *Gocal) parseEvent(l *Line) error {
 		gc.buffer.Categories = strings.Split(l.Value, ",")
 	case "URL":
 		gc.buffer.URL = l.Value
+    case "COMMENT":
+        gc.buffer.Comment = l.Value
 	default:
 		key := strings.ToUpper(l.Key)
 		if strings.HasPrefix(key, "X-") {

--- a/gocal_test.go
+++ b/gocal_test.go
@@ -20,10 +20,12 @@ DESCRIPTION:Amazing description on t
  wo lines
 LAST-MODIFIED:20141110T150010Z
 ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=Antoin
- e Popineau;X-NUM-GUESTS=0:mailto:antoine.popineau@example.net
+ e Popineau;X-NUM-GUESTS=0;X-RESPONSE-COMMENT="Not interested":mailto:antoi
+ ne.popineau@example.net
 ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=John
   Connor;X-NUM-GUESTS=0:mailto:john.connor@example.net
 LOCATION:My Place
+COMMENT;LANGUAGE=en-US:I don't think so.
 SEQUENCE:0
 STATUS:CONFIRMED
 SUMMARY:Lorem Ipsum Dolor Sit Amet
@@ -60,6 +62,9 @@ func Test_Parse(t *testing.T) {
 	assert.Equal(t, "0001@example.net", gc.Events[0].Uid)
 	assert.Equal(t, "Amazing description on two lines", gc.Events[0].Description)
 	assert.Equal(t, 2, len(gc.Events[0].Attendees))
+	assert.Equal(t, "Antoine Popineau", gc.Events[0].Attendees[0].Cn)
+	assert.Equal(t, "0", gc.Events[0].Attendees[0].CustomAttributes["X-NUM-GUESTS"])
+	assert.Equal(t, "\"Not interested\"", gc.Events[0].Attendees[0].CustomAttributes["X-RESPONSE-COMMENT"])
 	assert.Equal(t, "John Connor", gc.Events[0].Attendees[1].Cn)
 	assert.Equal(t, 0, len(gc.Events[0].CustomAttributes))
 	assert.Equal(t, 2, len(gc.Events[1].CustomAttributes))

--- a/types.go
+++ b/types.go
@@ -120,6 +120,7 @@ type Event struct {
 	Sequence         int
 	CustomAttributes map[string]string
 	Valid            bool
+    Comment          string
 }
 
 type Geo struct {
@@ -134,10 +135,11 @@ type Organizer struct {
 }
 
 type Attendee struct {
-	Cn          string
-	DirectoryDn string
-	Status      string
-	Value       string
+	Cn               string
+	DirectoryDn      string
+	Status           string
+	Value            string
+	CustomAttributes map[string]string
 }
 
 type Attachment struct {

--- a/types.go
+++ b/types.go
@@ -120,7 +120,7 @@ type Event struct {
 	Sequence         int
 	CustomAttributes map[string]string
 	Valid            bool
-    Comment          string
+	Comment          string
 }
 
 type Geo struct {


### PR DESCRIPTION
Use cases:

- Microsoft is using VEVENT COMMENT property to add attendee meeting notes.
- Google uses X-RESPONSE-COMMENT attendee attribute for the same purpose.

Details: https://www.kanzaki.com/docs/ical/comment.html