### PR TITLE
fix reoccurance expansion for BYDAY + COUNT rules

### DIFF
--- a/gocal_test.go
+++ b/gocal_test.go
@@ -107,6 +107,15 @@ RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU
 EXDATE;VALUE=DATE:20180129T090000Z
 END:VEVENT
 BEGIN:VEVENT
+DTSTART:20180101T090000Z
+DTEND:20180101T110000Z
+DTSTAMP:20151116T133227Z
+UID:0002@google.com
+SUMMARY:Every two weeks on mondays and tuesdays for three events
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU;COUNT=3
+EXDATE;VALUE=DATE:20180129T090000Z
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20180101T110000Z
 DTEND:20180101T130000Z
 DTSTAMP:20151116T133227Z
@@ -123,7 +132,7 @@ func Test_ReccuringRule(t *testing.T) {
 	gc.Start, gc.End = &start, &end
 	gc.Parse()
 
-	assert.Equal(t, 7, len(gc.Events))
+	assert.Equal(t, 9, len(gc.Events))
 
 	assert.Equal(t, "This changed!", gc.Events[0].Summary)
 	assert.Equal(t, "Every month on the second", gc.Events[2].Summary)

--- a/rrule.go
+++ b/rrule.go
@@ -69,7 +69,7 @@ func (gc *Gocal) ExpandRecurringEvent(buf *Event) []Event {
 
 		if !hasByMonth || strings.Contains(fmt.Sprintf("%d", byMonth), weekDaysStart.Format("1")) {
 			if hasByDay {
-				for i := 0; i < 7; i++ {
+				for i := 0; i < 7 && count != 0; i++ {
 					excluded := false
 					for _, ex := range buf.ExcludeDates {
 						if ex.Equal(*weekDaysStart) {


### PR DESCRIPTION
The ByDay expansion for loop was missing a count check, which made it possible for count to get decremented below zero, after which the COUNT rule was essentially dropped.. 

This Pull request adds the fix and appends one more testcase to the reoccurance rule test. 