### PR TITLE
change in opinionation about iCalendar-RFC-5545 section

### DIFF
--- a/examples/custom/custom.go
+++ b/examples/custom/custom.go
@@ -29,6 +29,19 @@ SUMMARY:Second event with custom labels
 X-ROOMID:802-127A
 X-COLOR:#ffffff
 END:VEVENT
+
+BEGIN:VEVENT
+DTSTAMP:20151116T133227Z
+DTSTART;VALUE=DATE:20210915T000000
+DTSTAMP:20151116T133227Z
+DTEND;VALUE=DATE:20210917T000000
+UID:three@gocal
+SUMMARY:Third event with custom Date
+X-ROOMID:802-127A
+X-COLOR:#ffffff
+SEQUENCE:0
+END:VEVENT
+
 END:VCALENDAR
 `
 
@@ -44,6 +57,7 @@ func main() {
 	c.Parse()
 
 	for _, e := range c.Events {
-		fmt.Printf("%s on %s - %s\n", e.Summary, e.CustomAttributes["X-ROOMID"], e.CustomAttributes["X-COLOR"])
+		fmt.Printf("%s on %s - %s from %s To %s\n", e.Summary, e.CustomAttributes["X-ROOMID"], e.CustomAttributes["X-COLOR"],
+			e.Start.Format("2006-01-02"), e.End.Format("2006-01-02"))
 	}
 }

--- a/parser/time.go
+++ b/parser/time.go
@@ -26,8 +26,10 @@ func ParseTime(s string, params map[string]string, ty int, allday bool, allDayTZ
 		/*
 			Reference: https://icalendar.org/iCalendar-RFC-5545/3-3-4-date.html
 			DATE values are a specific format.  They should not include time information
+
+			But sometimes dates will not comply, which is why s[:8] instead of s
 		*/
-		t, err := time.Parse("20060102", s)
+		t, err := time.Parse("20060102", s[:8])
 		if ty == TimeStart {
 			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, allDayTZ)
 		} else if ty == TimeEnd {


### PR DESCRIPTION
 https://icalendar.org/iCalendar-RFC-5545/3-3-4-date.html

Sometimes, despite `VALUE=DATE`,  it will not also be the case that ` len(s) == 8`. When that happens, the date and thus the entire VEVENT will fail to parse, and be omitted.

This change will parse the substring of the date, in case it is actually a Datetime, as many ics files often provide. As a result, the third example of custom.go will now be parsed successfully. 

<img width="798" alt="image" src="https://user-images.githubusercontent.com/31429832/170880661-b249bfc4-f48a-4044-ad3b-2a00e3b449cb.png">

_Before_
<img width="787" alt="image" src="https://user-images.githubusercontent.com/31429832/170880817-31e6f6c6-f379-47f5-b3c5-3c51c4541700.png">

_After_
<img width="688" alt="image" src="https://user-images.githubusercontent.com/31429832/170880796-c55d241e-6a17-4aa0-b777-8f9078a0ae41.png">

