### PR TITLE
Add support for quoted property parameters

### DIFF
--- a/gocal.go
+++ b/gocal.go
@@ -154,7 +154,7 @@ func (gc *Gocal) parseLine() (*Line, error, bool) {
 		}
 	}
 
-	tokens := strings.SplitN(l, ":", 2)
+	tokens := splitLineTokens(l)
 	if len(tokens) < 2 {
 		return nil, fmt.Errorf("could not parse item: %s", l), done
 	}
@@ -162,6 +162,30 @@ func (gc *Gocal) parseLine() (*Line, error, bool) {
 	attr, params := parser.ParseParameters(tokens[0])
 
 	return &Line{Key: attr, Params: params, Value: parser.UnescapeString(strings.TrimPrefix(tokens[1], " "))}, nil, done
+}
+
+// splitLineTokens assures that property parameters that are quoted due to containing special
+// characters (like COLON, SEMICOLON, COMMA) are not split.
+// See RFC5545, 3.1.1.
+func splitLineTokens(line string) []string {
+	// go's Split is highly optimized -> use, unless we cannot
+	if idxQuote := strings.Index(line, `"`); idxQuote == -1 {
+		return strings.SplitN(line, ":", 2)
+	} else if idxColon := strings.Index(line, ":"); idxQuote > idxColon {
+		return []string{line[0:idxColon], line[idxColon+1:]}
+	}
+
+	// otherwise, we need to do it ourselves, let's keep it simple at least:
+	quoted := false
+	size := len(line)
+	for idx, char := range []byte(line) {
+		if char == '"' {
+			quoted = !quoted
+		} else if char == ':' && !quoted && idx+1 < size {
+			return []string{line[0:idx], line[idx+1:]}
+		}
+	}
+	return []string{line}
 }
 
 func (gc *Gocal) parseEvent(l *Line) error {


### PR DESCRIPTION
This CL adds support for quoted property parameters (RFC5545, 3.1.1), specifically the following beauties that Office365 likes to spout out:

```
DTSTART;TZID="tzone://Microsoft/Utc":20230102T160000
```

This change adds a naive split implementation that respects said quoted parameters, which is only used in case quotes occur on the left-hand before the separating colon. The performance impact depends on the line-size of the properties in the ICS document. Benchmark measures about about 4ns for 20 char long lines, about 5ns for 100 char long lines.

```
$ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/apognu/gocal
Benchmark_splitLineTokens20-8    	35675428	        33.41 ns/op
Benchmark_stringSplitN20-8       	40056913	        29.56 ns/op
Benchmark_splitLineTokens100-8   	34151101	        34.99 ns/op
Benchmark_stringSplitN100-8      	39473630	        29.93 ns/op
PASS
ok  	github.com/apognu/gocal	5.900s
```